### PR TITLE
Create #x_and_y, but remove #username_and_password and hostname_and_port

### DIFF
--- a/lib/pendulum/dsl/output/base.rb
+++ b/lib/pendulum/dsl/output/base.rb
@@ -21,25 +21,14 @@ module Pendulum::DSL::Output
       url + (params.empty? ? '' : "?#{params}")
     end
 
-    def username_and_password
+    def x_and_y(x, y)
       case
-      when @username && @password
-        "#{@username}:#{@password}"
-      when @username
-        @username
-      when @password
-        ":#{@password}"
-      end
-    end
-
-    def hostname_and_port
-      case
-      when @hostname && @port
-        "#{@hostname}:#{@port}"
-      when @hostname
-        @hostname
-      when @port
-        ":#{@port}"
+      when x && y
+        "#{x}:#{y}"
+      when x
+        x
+      when y
+        ":#{y}"
       end
     end
   end

--- a/lib/pendulum/dsl/output/base.rb
+++ b/lib/pendulum/dsl/output/base.rb
@@ -31,5 +31,13 @@ module Pendulum::DSL::Output
         ":#{y}"
       end
     end
+
+    def username_and_password
+      x_and_y(@username, @password)
+    end
+
+    def hostname_and_port
+      x_and_y(@hostname, @port)
+    end
   end
 end

--- a/lib/pendulum/dsl/output/postgresql.rb
+++ b/lib/pendulum/dsl/output/postgresql.rb
@@ -4,7 +4,7 @@ module Pendulum::DSL::Output
                   :database, :table, :ssl, :schema, :mode, :method
 
     def to_url
-      url = "postgresql://#{x_and_y(@username, @password)}@#{x_and_y(@hostname, @port)}/#{@database}/#{@table}"
+      url = "postgresql://#{username_and_password}@#{hostname_and_port}/#{@database}/#{@table}"
       with_options(url, :ssl, :schema, :mode, :method)
     end
   end

--- a/lib/pendulum/dsl/output/postgresql.rb
+++ b/lib/pendulum/dsl/output/postgresql.rb
@@ -4,7 +4,7 @@ module Pendulum::DSL::Output
                   :database, :table, :ssl, :schema, :mode, :method
 
     def to_url
-      url = "postgresql://#{username_and_password}@#{hostname_and_port}/#{@database}/#{@table}"
+      url = "postgresql://#{x_and_y(@username, @password)}@#{x_and_y(@hostname, @port)}/#{@database}/#{@table}"
       with_options(url, :ssl, :schema, :mode, :method)
     end
   end

--- a/spec/pendulum/dsl/output/base_spec.rb
+++ b/spec/pendulum/dsl/output/base_spec.rb
@@ -1,0 +1,53 @@
+describe Pendulum::DSL::Output::Base do
+  let(:dsl) { described_class.new }
+
+  describe '::initialize' do
+    subject { dsl.instance_variables }
+
+    context 'when block is given' do
+      let(:dsl) { described_class.new { @hoge = 100 } }
+      it { is_expected.to include(:@hoge) }
+    end
+
+    context 'when no block is given' do
+      it { is_expected.to be_empty }
+    end
+  end
+
+  describe '#to_url' do
+    subject { dsl.to_url }
+
+    it 'raise NotImplementedError' do
+      expect { subject }.to raise_error(
+        NotImplementedError,
+        'You must implement Pendulum::DSL::Output::Base#to_url')
+    end
+  end
+
+  describe '#x_and_y' do
+    subject { dsl.send(:x_and_y, x, y) }
+
+    before(:each) do
+      dsl.instance_variable_set(:@username, x)
+      dsl.instance_variable_set(:@password, y)
+    end
+
+    context 'when both params x and y truthy' do
+      let(:x) { 'jordan' }
+      let(:y) { 'MJ2345' }
+      it { is_expected.to eq 'jordan:MJ2345' }
+    end
+
+    context 'when only param x is truthy' do
+      let(:x) { 'jordan' }
+      let(:y) { nil }
+      it { is_expected.to eq 'jordan' }
+    end
+
+    context 'when only param y is truthy' do
+      let(:x) { nil }
+      let(:y) { 'MJ2345' }
+      it { is_expected.to eq ':MJ2345' }
+    end
+  end
+end

--- a/spec/pendulum/dsl/output/base_spec.rb
+++ b/spec/pendulum/dsl/output/base_spec.rb
@@ -1,6 +1,25 @@
 describe Pendulum::DSL::Output::Base do
   let(:dsl) { described_class.new }
 
+  shared_context 'set @username and @password' do
+    before(:each) do
+      dsl.instance_variable_set(:@username, x)
+      dsl.instance_variable_set(:@password, y)
+    end
+  end
+
+  shared_context 'set @hostname and @port' do
+    before(:each) do
+      dsl.instance_variable_set(:@hostname, x)
+      dsl.instance_variable_set(:@port, y)
+    end
+  end
+
+  shared_context 'set x and y' do
+    let(:x) { 'any' }
+    let(:y) { 'thing' }
+  end
+
   describe '::initialize' do
     subject { dsl.instance_variables }
 
@@ -26,16 +45,11 @@ describe Pendulum::DSL::Output::Base do
 
   describe '#x_and_y' do
     subject { dsl.send(:x_and_y, x, y) }
-
-    before(:each) do
-      dsl.instance_variable_set(:@username, x)
-      dsl.instance_variable_set(:@password, y)
-    end
+    include_context 'set @username and @password'
 
     context 'when both params x and y truthy' do
-      let(:x) { 'jordan' }
-      let(:y) { 'MJ2345' }
-      it { is_expected.to eq 'jordan:MJ2345' }
+      include_context 'set x and y'
+      it { is_expected.to eq 'any:thing' }
     end
 
     context 'when only param x is truthy' do
@@ -48,6 +62,26 @@ describe Pendulum::DSL::Output::Base do
       let(:x) { nil }
       let(:y) { 'MJ2345' }
       it { is_expected.to eq ':MJ2345' }
+    end
+  end
+
+  describe '#username_and_password' do
+    include_context 'set @username and @password'
+    include_context 'set x and y'
+
+    it 'calls x_and_y' do
+      expect(dsl).to receive(:x_and_y).with(x, y).once
+      dsl.send(:username_and_password)
+    end
+  end
+
+  describe '#hostname_and_port' do
+    include_context 'set @hostname and @port'
+    include_context 'set x and y'
+
+    it 'calls x_and_y' do
+      expect(dsl).to receive(:x_and_y).with(x, y).once
+      dsl.send(:hostname_and_port)
     end
   end
 end


### PR DESCRIPTION
Because `#username_and_password` and `#hostname_and_port` are almost identical.
