### PR TITLE
Allow providing API key in an environment variable

### DIFF
--- a/lib/pendulum/runner.rb
+++ b/lib/pendulum/runner.rb
@@ -5,7 +5,7 @@ module Pendulum
   DEFAULT_SCHEDFILE = 'Schedfile'
   class Runner
     def run(argv=ARGV)
-      api_key = nil
+      api_key = ENV['TD_API_KEY']
       mode    = nil
       dry_run = false
       force   = false


### PR DESCRIPTION
Exposing secret data such as an API key on a command line is not secure.
This patch allows users to use the environment variable `TD_API_KEY` to provide the key.
